### PR TITLE
Data gatherer tests

### DIFF
--- a/jarjarquant/data_gatherer.py
+++ b/jarjarquant/data_gatherer.py
@@ -192,6 +192,7 @@ class DataGatherer:
             return df
 
         # Use a ThreadPoolExecutor to run fetch_data_for_ticker concurrently.
+        util.startLoop()
         loop = asyncio.get_running_loop()
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_tickers_to_sample) as executor:
             tasks = [

--- a/jarjarquant/feature_evaluator.py
+++ b/jarjarquant/feature_evaluator.py
@@ -419,7 +419,7 @@ class FeatureEvaluator:
         with concurrent.futures.ProcessPoolExecutor() as executor:
             data_gatherer = DataGatherer()
             futures = [executor.submit(
-                data_gatherer.get_random_price_samples, num_tickers_to_sample=1) for _ in range(n_runs)]
+                data_gatherer.get_random_price_samples_yf, num_tickers_to_sample=1) for _ in range(n_runs)]
             for future in concurrent.futures.as_completed(futures):
                 ohlcv_df = future.result()[0]
                 indicator_values = indicator_func(
@@ -458,7 +458,7 @@ class FeatureEvaluator:
         kwargs = inputs["kwargs"]
 
         data_gatherer = DataGatherer()
-        ohlcv_df = data_gatherer.get_random_price_samples(
+        ohlcv_df = data_gatherer.get_random_price_samples_yf(
             num_tickers_to_sample=1)[0]
         indicator_instance = indicator_func(ohlcv_df, **kwargs)
 

--- a/jarjarquant/jarjarquant.py
+++ b/jarjarquant/jarjarquant.py
@@ -64,7 +64,7 @@ class Jarjarquant(Labeller):
             Jarjarquant: Instance of Jarjarquant with generated series.
         """
         data_gatherer = DataGatherer()
-        samples = data_gatherer.get_random_price_samples(
+        samples = data_gatherer.get_random_price_samples_yf(
             num_tickers_to_sample=num_tickers_to_sample, years_in_sample=years_in_sample, **kwargs)
         if not samples:
             raise ValueError(

--- a/tests/test_data_gatherer.py
+++ b/tests/test_data_gatherer.py
@@ -1,0 +1,49 @@
+import pytest
+import pandas as pd
+from jarjarquant.data_gatherer import DataGatherer
+
+
+@pytest.fixture
+def data_gatherer():
+    return DataGatherer()
+
+
+def test_generate_random_normal(data_gatherer):
+    series = data_gatherer.generate_random_normal()
+    assert isinstance(series, pd.Series)
+    assert len(series) == 252
+    assert series.name == 'price'
+
+
+def test_get_yf_ticker():
+    series = DataGatherer.get_yf_ticker("AAPL")
+    assert isinstance(series, pd.DataFrame)
+    assert not series.empty
+    assert all(col in series.columns for col in [
+               'Open', 'High', 'Low', 'Close', 'Volume'])
+
+
+@pytest.mark.asyncio
+async def test_get_tws_ticker():
+    df = await DataGatherer.get_tws_ticker(ticker='AAPL', end_date='20031126 15:59:00 US/Eastern')
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+
+
+def test_get_random_price_samples_yf(data_gatherer):
+    dataframes = data_gatherer.get_random_price_samples_yf()
+    assert isinstance(dataframes, list)
+    assert len(dataframes) == 30
+    for df in dataframes:
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+
+@pytest.mark.asyncio
+async def test_get_random_price_samples_tws(data_gatherer):
+    dataframes = await data_gatherer.get_random_price_samples_tws(num_tickers_to_sample=1, years_in_sample=1)
+    assert isinstance(dataframes, list)
+    assert len(dataframes) == 1
+    for df in dataframes:
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty

--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -1,111 +1,93 @@
-import unittest
+import pytest
 import pandas as pd
 import numpy as np
 from jarjarquant.feature_engineer import BarPermute, PricePermute
 
 
-class TestPricePermute(unittest.TestCase):
-
-    def setUp(self):
-        # Create sample price series data
-        dates = pd.date_range(start='2020-01-01', periods=100, freq='D')
-        data1 = np.cumsum(np.random.randn(100))
-        data2 = np.cumsum(np.random.randn(100))
-        self.series1 = pd.Series(data1, index=dates)
-        self.series2 = pd.Series(data2, index=dates)
-        self.price_series_list = [self.series1, self.series2]
-
-    def test_initialization(self):
-        # Test initialization of PricePermute
-        pp = PricePermute(self.price_series_list)
-        self.assertEqual(pp.n_markets, 2)
-        self.assertEqual(len(pp.price_series_list), 2)
-        self.assertEqual(pp.price_series_list[0].iloc[0], self.series1.iloc[0])
-        self.assertEqual(pp.price_series_list[1].iloc[0], self.series2.iloc[0])
-
-    def test_initialization_with_empty_list(self):
-        # Test initialization with empty list
-        with self.assertRaises(ValueError):
-            PricePermute([])
-
-    def test_initialization_with_different_lengths(self):
-        # Test initialization with series of different lengths
-        series3 = self.series1[:-1]
-        with self.assertRaises(ValueError):
-            PricePermute([self.series1, series3])
-
-    def test_permute(self):
-        # Test permute method
-        pp = PricePermute(self.price_series_list)
-        shuffled_series_list = pp.permute()
-        self.assertEqual(len(shuffled_series_list), 2)
-        self.assertEqual(len(shuffled_series_list[0]), 100)
-        self.assertEqual(len(shuffled_series_list[1]), 100)
-        self.assertTrue(
-            (shuffled_series_list[0].index == self.series1.index).all())
-        self.assertTrue(
-            (shuffled_series_list[1].index == self.series2.index).all())
+@pytest.fixture
+def price_series_list():
+    dates = pd.date_range(start='2020-01-01', periods=100, freq='D')
+    data1 = np.cumsum(np.random.randn(100))
+    data2 = np.cumsum(np.random.randn(100))
+    series1 = pd.Series(data1, index=dates)
+    series2 = pd.Series(data2, index=dates)
+    return [series1, series2]
 
 
-class TestBarPermute(unittest.TestCase):
-    """
-    Unit tests for the BarPermute class.
-    TestBarPermute is a unittest.TestCase subclass that tests the functionality of the BarPermute class.
-    It includes the following test methods:
-    - setUp: Initializes sample OHLC data for testing.
-    - test_initialization: Tests the initialization of the BarPermute class.
-    - test_permute: Tests the permute method of the BarPermute class.
-    - test_invalid_initialization: Tests the initialization of BarPermute with an empty list.
-    - test_permute_length_mismatch: Tests the permute method when there is a length mismatch in the index.
-    """
-
-    def setUp(self):
-        # Create sample OHLC data
-        dates = pd.date_range('2023-01-01', periods=5)
-        data1 = {
-            'Open': [1, 2, 3, 4, 5],
-            'High': [2, 3, 4, 5, 6],
-            'Low': [0.5, 1.5, 2.5, 3.5, 4.5],
-            'Close': [1.5, 2.5, 3.5, 4.5, 5.5]
-        }
-        data2 = {
-            'Open': [10, 20, 30, 40, 50],
-            'High': [20, 30, 40, 50, 60],
-            'Low': [5, 15, 25, 35, 45],
-            'Close': [15, 25, 35, 45, 55]
-        }
-        self.df1 = pd.DataFrame(data1, index=dates)
-        self.df2 = pd.DataFrame(data2, index=dates)
-        self.ohlc_df_list = [self.df1, self.df2]
-
-    def test_initialization(self):
-        bar_permute = BarPermute(self.ohlc_df_list)
-        self.assertEqual(bar_permute.n_markets, 2)
-        self.assertEqual(bar_permute.original_index.tolist(),
-                         self.df1.index.tolist())
-        self.assertEqual(len(bar_permute.rel_prices), 2)
-
-    def test_permute(self):
-        bar_permute = BarPermute(self.ohlc_df_list)
-        shuffled_df_list = bar_permute.permute()
-        self.assertEqual(len(shuffled_df_list), 2)
-        for df in shuffled_df_list:
-            self.assertEqual(len(df), len(self.df1))
-            self.assertTrue(
-                all(df.columns == ['Open', 'High', 'Low', 'Close']))
-            self.assertTrue(all(df.index == self.df1.index))
-
-    def test_invalid_initialization(self):
-        with self.assertRaises(ValueError):
-            BarPermute([])
-
-    def test_permute_length_mismatch(self):
-        bar_permute = BarPermute(self.ohlc_df_list)
-        # Modify the index length
-        bar_permute.original_index = bar_permute.original_index[:-1]
-        with self.assertRaises(ValueError):
-            bar_permute.permute()
+def test_price_permute_initialization(price_series_list):
+    pp = PricePermute(price_series_list)
+    assert pp.n_markets == 2
+    assert len(pp.price_series_list) == 2
+    assert pp.price_series_list[0].iloc[0] == price_series_list[0].iloc[0]
+    assert pp.price_series_list[1].iloc[0] == price_series_list[1].iloc[0]
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_price_permute_initialization_with_empty_list():
+    with pytest.raises(ValueError):
+        PricePermute([])
+
+
+def test_price_permute_initialization_with_different_lengths(price_series_list):
+    series3 = price_series_list[0][:-1]
+    with pytest.raises(ValueError):
+        PricePermute([price_series_list[0], series3])
+
+
+def test_price_permute_permute(price_series_list):
+    pp = PricePermute(price_series_list)
+    shuffled_series_list = pp.permute()
+    assert len(shuffled_series_list) == 2
+    assert len(shuffled_series_list[0]) == 100
+    assert len(shuffled_series_list[1]) == 100
+    assert (shuffled_series_list[0].index == price_series_list[0].index).all()
+    assert (shuffled_series_list[1].index == price_series_list[1].index).all()
+
+
+@pytest.fixture
+def ohlc_df_list():
+    dates = pd.date_range('2023-01-01', periods=5)
+    data1 = {
+        'Open': [1, 2, 3, 4, 5],
+        'High': [2, 3, 4, 5, 6],
+        'Low': [0.5, 1.5, 2.5, 3.5, 4.5],
+        'Close': [1.5, 2.5, 3.5, 4.5, 5.5]
+    }
+    data2 = {
+        'Open': [10, 20, 30, 40, 50],
+        'High': [20, 30, 40, 50, 60],
+        'Low': [5, 15, 25, 35, 45],
+        'Close': [15, 25, 35, 45, 55]
+    }
+    df1 = pd.DataFrame(data1, index=dates)
+    df2 = pd.DataFrame(data2, index=dates)
+    return [df1, df2]
+
+
+def test_bar_permute_initialization(ohlc_df_list):
+    bar_permute = BarPermute(ohlc_df_list)
+    assert bar_permute.n_markets == 2
+    assert bar_permute.original_index.tolist(
+    ) == ohlc_df_list[0].index.tolist()
+    assert len(bar_permute.rel_prices) == 2
+
+
+def test_bar_permute_permute(ohlc_df_list):
+    bar_permute = BarPermute(ohlc_df_list)
+    shuffled_df_list = bar_permute.permute()
+    assert len(shuffled_df_list) == 2
+    for df in shuffled_df_list:
+        assert len(df) == len(ohlc_df_list[0])
+        assert all(df.columns == ['Open', 'High', 'Low', 'Close'])
+        assert all(df.index == ohlc_df_list[0].index)
+
+
+def test_bar_permute_invalid_initialization():
+    with pytest.raises(ValueError):
+        BarPermute([])
+
+
+def test_bar_permute_permute_length_mismatch(ohlc_df_list):
+    bar_permute = BarPermute(ohlc_df_list)
+    bar_permute.original_index = bar_permute.original_index[:-1]
+    with pytest.raises(ValueError):
+        bar_permute.permute()


### PR DESCRIPTION
This pull request includes several changes to improve data gathering, refactor code, and enhance testing in the `jarjarquant` project. Key changes include the addition of asyncio loop initialization, refactoring methods to use the new `get_random_price_samples_yf` function, and transitioning from `unittest` to `pytest` for testing.

Closes #17 
Closes #18 

### Data Gathering Improvements:
* Added `util.startLoop()` to initialize the asyncio loop in `fetch_data_for_ticker` function.

### Refactoring:
* Updated `parallel_indicator_threshold_search`, `single_indicator_evaluation`, and `from_random_sample` functions to use the new `get_random_price_samples_yf` method instead of `get_random_price_samples`. [[1]](diffhunk://#diff-941a4b057ac8ba6f47d8cf63c5bcc97216097e981f2db0f79d1fb1cbad54af53L422-R422) [[2]](diffhunk://#diff-941a4b057ac8ba6f47d8cf63c5bcc97216097e981f2db0f79d1fb1cbad54af53L461-R461) [[3]](diffhunk://#diff-6148701b792b54c1c590233a5fe4d8ecd68b44d3074b186f760d9a092201d65eL67-R67)

### Testing Enhancements:
* Added new tests for `DataGatherer` methods, including `generate_random_normal`, `get_yf_ticker`, `get_random_price_samples_yf`, and `get_random_price_samples_tws`.
* Refactored tests in `test_feature_engineer.py` to use `pytest` instead of `unittest`, including the introduction of pytest fixtures and updating test methods accordingly. [[1]](diffhunk://#diff-f07c630da61baf9b6642f3181306888a6394b0475b1230cbb88b47f5960f4f50L1-R47) [[2]](diffhunk://#diff-f07c630da61baf9b6642f3181306888a6394b0475b1230cbb88b47f5960f4f50L77-L111)